### PR TITLE
Don't add the link if it already exists

### DIFF
--- a/Github_Pages_Linker/Github_Pages_Linker.user.js
+++ b/Github_Pages_Linker/Github_Pages_Linker.user.js
@@ -29,9 +29,10 @@
 	};
 
 	function addLink() {
-		if(document.getElementById('GithubPagesLinker')) {
+		if(document.getElementById("GithubPagesLinker")) {
 			return;
 		}
+
 		var meta = document.querySelector(".repository-meta");
 		if (!meta) {
 			return;
@@ -46,7 +47,7 @@
 		var url = String.format("https://{0}.github.io/{1}", tree[1], tree[2]);
 
 		var div = document.createElement("div");
-		div.id='GithubPagesLinker';
+		div.id = "GithubPagesLinker";
 		div.style.margin = "-10px 0px 10px";
 		meta.parentNode.insertBefore(div, meta.nextSibling);
 

--- a/Github_Pages_Linker/Github_Pages_Linker.user.js
+++ b/Github_Pages_Linker/Github_Pages_Linker.user.js
@@ -12,7 +12,7 @@
 // @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Pages_Linker/Github_Pages_Linker.user.js
 // @supportURL  https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     1.1
+// @version     1.2
 // @grant       none
 // @run-at      document-end
 // @include     https://github.com/*
@@ -29,6 +29,9 @@
 	};
 
 	function addLink() {
+		if(document.getElementById('GithubPagesLinker')) {
+			return;
+		}
 		var meta = document.querySelector(".repository-meta");
 		if (!meta) {
 			return;
@@ -43,7 +46,7 @@
 		var url = String.format("https://{0}.github.io/{1}", tree[1], tree[2]);
 
 		var div = document.createElement("div");
-		div.classList.add('GithubPagesLinker');
+		div.id='GithubPagesLinker';
 		div.style.margin = "-10px 0px 10px";
 		meta.parentNode.insertBefore(div, meta.nextSibling);
 


### PR DESCRIPTION
When I use browser history to to back/forward on github, every time I see the main repo page, it creates a new link below the others. This fixes that--it switches to using an id instead of a class, and it'll only make an element if there isn't one already.

I'm using chrome with tampermonkey if that makes a difference.