### PR TITLE
(GitHub News Feed Filter) 'Sidebar is null' error in Browser Console

### DIFF
--- a/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+++ b/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
@@ -496,7 +496,7 @@
 		var newsContainer = document.querySelector(".news");
 		if (!newsContainer) { return; }
 
-		var sidebar = document.querySelector(".dashboard-sidebar") || document.querySelector(".column.one-fourth.vcard");
+		var sidebar = document.querySelector(".vcard-avatar"); 
 
 		var wrapper = document.createElement(filterElement);
 		wrapper.classList.add("boxed-group", "flush", "user-repos");


### PR DESCRIPTION
The script shows `Sidebar is null` error in Browser Console on users public activity stream.
This is a suggested fix.