### PR TITLE
(GitHub News Feed Filter) Fix for 'Actions' tab|'Wiki' being empty after GitHub site update 

### DIFF
--- a/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+++ b/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
@@ -325,7 +325,7 @@
 		Array.prototype.map.call(newsContainer.querySelectorAll(':scope > div > .body'), function(alert) {
 			return alert.parentNode;
 		}).forEach(function(alert) {
-			var alertRepo = alert.querySelector(':scope .flex-items-baseline > div > [data-ga-click*="target:repo"]');
+			var alertRepo = alert.querySelector('[data-ga-click*="target:repo"]');
 			if (alertRepo) { // Follow doesn't contain a repo link.
 				var userRepo = alertRepo.textContent;
 				userRepos.add(userRepo);

--- a/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+++ b/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
@@ -325,7 +325,7 @@
 		Array.prototype.map.call(newsContainer.querySelectorAll(':scope > div > .body'), function(alert) {
 			return alert.parentNode;
 		}).forEach(function(alert) {
-			var alertRepo = alert.querySelector('[data-ga-click*="target:repo"]');
+			var alertRepo = alert.querySelector(':scope [data-ga-click*="target:repo"]');
 			if (alertRepo) { // Follow doesn't contain a repo link.
 				var userRepo = alertRepo.textContent;
 				userRepos.add(userRepo);

--- a/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+++ b/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
@@ -308,9 +308,9 @@
 				alert.classList.add('tag_remove');
 			} else if (alert.classList.contains('gollum')) {
 				alert.classList.remove('gollum');
-				if (!!~alert.textContent.indexOf(' created the ')) {
+				if (!!~alert.innerText.indexOf(' created a wiki page in ')) {
 					alert.classList.add('wiki_created');
-				} else if (!!~alert.textContent.indexOf(' edited a wiki page in ')) {
+				} else if (!!~alert.innerText.indexOf(' edited a wiki page in ')) {
 					alert.classList.add('wiki_edited');
 				}
 			}


### PR DESCRIPTION
Fix for 'Actions' tab|'Wiki' being empty after GitHub site update (additional re-fix for #124)

Note: I changed textContent with innerText, because it contains linebreaks and spaces in HTML (i.e. with textContent).