### PR TITLE
:bug: Fix after GitHub site update

### DIFF
--- a/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
+++ b/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
@@ -3,6 +3,7 @@
 // @namespace   https://github.com/jerone/UserScripts
 // @description Add controls to compare commits.
 // @author      jerone
+// @contributor darkred
 // @copyright   2017+, jerone (http://jeroenvanwarmerdam.nl)
 // @license     GPL-3.0
 // @homepage    https://github.com/jerone/UserScripts/tree/master/GitHub_Commit_Compare
@@ -16,7 +17,7 @@
 // @include     https://github.com/*/*/commits/*
 // @exclude     https://github.com/*/*.diff
 // @exclude     https://github.com/*/*.patch
-// @version     0.0.1
+// @version     0.0.2
 // @grant       none
 // ==/UserScript==
 
@@ -143,9 +144,9 @@
     const repo = document.querySelector('meta[property="og:url"]').content;
 
     const compareA = document.querySelector('.GitHubCommitCompareButtonAB [name="GitHubCommitCompareButtonA"]:checked');
-    const hashA = compareA.parentNode.parentNode.parentNode.querySelector('[data-clipboard-text]').dataset.clipboardText;
+    const hashA = compareA.parentNode.parentNode.parentNode.querySelector('clipboard-copy').value;
     const compareB = document.querySelector('.GitHubCommitCompareButtonAB [name="GitHubCommitCompareButtonB"]:checked');
-    const hashB = compareB.parentNode.parentNode.parentNode.querySelector('[data-clipboard-text]').dataset.clipboardText;
+    const hashB = compareB.parentNode.parentNode.parentNode.querySelector('clipboard-copy').value;
 
     const a = document.getElementById('GitHubCommitCompareButton');
     a.setAttribute('href', `${repo}/compare/${hashA}...${hashB}`);

--- a/GitHub_Commit_Compare/README.md
+++ b/GitHub_Commit_Compare/README.md
@@ -19,6 +19,19 @@ Add controls to compare commits.
 
 ## Version History
 
+*   **0.0.2**
+
+    *   🐛 Fix after GitHub site update (fixed by [@darkred](https://github.com/darkred) in [#128](https://github.com/jerone/UserScripts/issues/128)).
+
 *   **0.0.1**
 
     *   Initial version.
+
+## Contributors
+
+*   [darkred](https://github.com/darkred)
+
+## External links
+
+*   [Greasy Fork](https://greasyfork.org/en/scripts/33563-github-commit-compare)
+*   [OpenUserJS](https://openuserjs.org/scripts/jerone/GitHub_Commit_Compare)


### PR DESCRIPTION
Hey @jerone 

I've made a few tweaks to make 'GitHub Commit Compare' work after the recent GitHub site update.

---

Two things to note, please:
- the script currently doesn't work when you follow links, 
i.e. it doesn't work while being e.g. here https://github.com/jerone/UserScripts if you follow the link [526 Commits](https://github.com/jerone/UserScripts/commits/master) - it only works if you refresh the page while already being in the Commits page.

- <sup>I've taken the liberty of adding my nick as 'Contributor' in this PR (as I did in my other PR, for 'Github News Feed Filter' too). I just hope it's ok with you (sorry I didn't ask you first!). Otherwise (maybe because my tweaks are minor/basic and/or simply because it's your personal work), please feel free to remove `// @contributor darkred` (and from the other script, too). No problem at all.</sup>