### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repo contains a few of my UserScripts that I've build since [2007](http://u
 
 ### Outlook
 
--   [Multiple Windows Live ID's](https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs#readme) - Easy login with multiple Microsoft accounts.
+-   [Multiple Windows Live IDs](https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs#readme) - Easy login with multiple Microsoft accounts.
 -   [Outlook Sign Out To Login](https://github.com/jerone/UserScripts/tree/master/Outlook_Sign_Out_To_Login#readme) - Redirect back to login page when signing out from Outlook.
 
 ### Dutch


### PR DESCRIPTION
Small typo fix. Plural of something is with `s` (and not `'s`).