### PR TITLE
fix Github Pages Linker for new UI in 2021

### DIFF
--- a/Github_Pages_Linker/Github_Pages_Linker.user.js
+++ b/Github_Pages_Linker/Github_Pages_Linker.user.js
@@ -14,7 +14,7 @@
 // @supportURL  https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
 // @icon        https://github.githubassets.com/pinned-octocat.svg
-// @version     1.2.3
+// @version     1.2.4
 // @grant       none
 // @run-at      document-end
 // @include     https://github.com/*
@@ -28,59 +28,77 @@
 			return typeof args[number] !== "undefined" ? args[number] : match;
 		});
 	};
+  
+  var DELAY = 2500;
+
+  var triggerEventClick = new MouseEvent('click', {
+     view: window,
+     bubbles: true,
+     cancelable: true
+  });
 
 	function addLink() {
 		if(document.getElementById("GithubPagesLinker")) {
 			return;
 		}
+    
+    var closeDropdown = () => {
+      document.querySelector('[data-toggle-for="branch-select-menu"]').dispatchEvent(triggerEventClick);
+    }
 
-		var meta = document.querySelector(".repository-meta");
-		if (!meta) {
-			return;
-		}
+    var dropdown = document.querySelector('[data-hotkey="w"]');
+    dropdown.dispatchEvent(triggerEventClick); // open menu to load data
 
-		var branch = document.querySelector(".js-navigation-open[data-name='gh-pages']");
-		if (!branch) {
-			return;
-		}
+    setTimeout(() => {
+      var meta = document.querySelector('.file-navigation');
 
-		var tree = branch.getAttribute("href").split("/"); // `/{user}/{repo}/tree/gh-pages`;
-		var url = String.format("https://{0}.github.io/{1}/", tree[1], tree[2]);
+      var branch = document.querySelector('.SelectMenu-item[href$="/tree/gh-pages"]');
+      if (!branch) {
+        closeDropdown();
+        return;
+      }
 
-		var div = document.createElement("div");
-		div.id = "GithubPagesLinker";
-		div.style.margin = "-10px 0px 10px";
-		meta.parentNode.insertBefore(div, meta.nextSibling);
+      var tree = branch.getAttribute("href").split("/"); // `/{user}/{repo}/tree/gh-pages`;
+      var url = String.format("{0}//{1}.github.io/{2}/", tree[0], tree[3], tree[4]);
 
-		var img = document.createElement("img");
-		img.setAttribute("src", "https://assets-cdn.github.com/images/icons/emoji/octocat.png");
-		img.setAttribute("align", "absmiddle");
-		img.classList.add("emoji");
-		img.style.height = "16px";
-		img.style.width = "16px";
-		div.appendChild(img);
+      var div = document.createElement("div");
+      div.id = "GithubPagesLinker";
+      div.style.margin = "-10px 0px 10px";
+      meta.parentNode.insertBefore(div, meta.nextSibling);
 
-		div.appendChild(document.createTextNode(" "));
+      var img = document.createElement("img");
+      img.setAttribute("src", "https://github.githubassets.com/images/icons/emoji/octocat.png");
+      img.setAttribute("align", "absmiddle");
+      img.classList.add("emoji");
+      img.style.height = "16px";
+      img.style.width = "16px";
+      div.appendChild(img);
 
-		var a = document.createElement("a");
-		a.setAttribute("href", "https://pages.github.com");
-		a.setAttribute("title", "More info about gh-pages...");
-		a.style.color = "inherit";
-		a.appendChild(document.createTextNode("Github Pages"));
-		div.appendChild(a);
+      div.appendChild(document.createTextNode(" "));
 
-		div.appendChild(document.createTextNode(": "));
+      var a = document.createElement("a");
+      a.setAttribute("href", "{https}://pages.github.com");
+      a.setAttribute("title", "More info about gh-pages...");
+      a.style.color = "inherit";
+      a.appendChild(document.createTextNode("Github Pages"));
+      div.appendChild(a);
 
-		var aa = document.createElement("a");
-		aa.setAttribute("href", url);
-		aa.appendChild(document.createTextNode(url));
-		div.appendChild(aa);
+      div.appendChild(document.createTextNode(": "));
+
+      var aa = document.createElement("a");
+      aa.setAttribute("href", url);
+      aa.appendChild(document.createTextNode(url));
+      div.appendChild(aa);
+      
+      closeDropdown();
+      
+    }, DELAY);
 	}
 
 	// Init;
 	addLink();
 
 	// On pjax;
-    document.addEventListener('pjax:end', addLink);
+  document.addEventListener('pjax:end', addLink);
 
 })();

--- a/Github_Pages_Linker/Github_Pages_Linker.user.js
+++ b/Github_Pages_Linker/Github_Pages_Linker.user.js
@@ -29,7 +29,7 @@
 		});
 	};
   
-  var DELAY = 2500;
+  var DELAY = 800;
 
   var triggerEventClick = new MouseEvent('click', {
      view: window,
@@ -37,10 +37,15 @@
      cancelable: true
   });
 
-	function addLink() {
-		if(document.getElementById("GithubPagesLinker")) {
-			return;
-		}
+  function addLink() {
+	if(document.getElementById("GithubPagesLinker")) {
+	  return;
+    }
+
+    var meta = document.querySelector('.file-navigation');
+    if (!meta) {
+      return;
+    }
     
     var closeDropdown = () => {
       document.querySelector('[data-toggle-for="branch-select-menu"]').dispatchEvent(triggerEventClick);
@@ -50,8 +55,6 @@
     dropdown.dispatchEvent(triggerEventClick); // open menu to load data
 
     setTimeout(() => {
-      var meta = document.querySelector('.file-navigation');
-
       var branch = document.querySelector('.SelectMenu-item[href$="/tree/gh-pages"]');
       if (!branch) {
         closeDropdown();


### PR DESCRIPTION
* Github is lazy loading the list of branches, so we are using setInterval to wait for the values.
* octocat icon waas 404, new icon has been updated with correct URL