### PR TITLE
(Github Image Viewer) :bug: Fixed loader animation source

### DIFF
--- a/Github_Image_Viewer/Github_Image_Viewer.user.js
+++ b/Github_Image_Viewer/Github_Image_Viewer.user.js
@@ -47,7 +47,7 @@
 		_floaterMeta: null,
 
 		_imageUrl: null,
-		_loaderSrc: "https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif",
+		_loaderSrc: "https://github.githubassets.com/images/spinners/octocat-spinner-32.gif",
 		_imageRegex: /.+(\.jpe?g|\.png|\.gif|\.bmp|\.ico|\.tiff?)$/i,
 
 		Initialize: function() {


### PR DESCRIPTION
Before:
![Before](https://i.imgur.com/4F0hOZz.png)

After:
![After](https://i.imgur.com/dEa28SL.png)

Closes https://github.com/jerone/UserScripts/issues/155