### PR TITLE
feat: use `eslint-plugin-userscripts`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,39 @@
+module.exports = {
+	env: {
+		browser: true,
+		greasemonkey: true,
+		es2021: true,
+	},
+	overrides: [
+		{
+			env: {
+				node: true,
+			},
+			files: [".eslintrc.{js,cjs}"],
+			parserOptions: {
+				sourceType: "script",
+			},
+		},
+		{
+			files: ["*.user.js"],
+			extends: ["plugin:userscripts/recommended"],
+			rules: {
+				"userscripts/align-attributes": ["error", 1],
+				"userscripts/no-invalid-headers": ["error", { allowed: ["id", "browser"] }],
+				"userscripts/compat-headers": "off",
+			},
+			settings: {
+				userscriptVersions: {
+					tampermonkey: ">=4",
+					violentmonkey: ">=2",
+					greasemonkey: "*",
+				},
+			},
+		},
+	],
+	parserOptions: {
+		ecmaVersion: "latest",
+	},
+	rules: {},
+};
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.suo
 *.bak
 *.vs
+
+.DS_Store
+node_modules/
+pnpm-lock.yaml

--- a/April_Fools_CSS/April_Fools_CSS.user.js
+++ b/April_Fools_CSS/April_Fools_CSS.user.js
@@ -1,15 +1,15 @@
 // ==UserScript==
-// @name           April Fools CSS
-// @description    Some CSS april fools
-// @author         jerone
-// @namespace      https://github.com/jerone/UserScripts/tree/master/April_Fools_CSS
-// @copyright      2014+, jerone (https://github.com/jerone)
-// @license        CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license        GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @supportURL     https://github.com/jerone/UserScripts/issues
+// @name            April Fools CSS
+// @description     Some CSS april fools
+// @author          jerone
+// @namespace       https://github.com/jerone/UserScripts/tree/master/April_Fools_CSS
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include        *
-// @version        1.0
+// @include         *
+// @version         1.0
 // ==/UserScript==
 
 if(window.top===window){

--- a/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
+++ b/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
@@ -1,22 +1,22 @@
 // ==UserScript==
-// @id          Darts_Data_Enhancer@https://github.com/jerone/UserScripts
-// @name        Darts Data Enhancer
-// @namespace   https://github.com/jerone/UserScripts
-// @description Enhances Darts Data
-// @author      jerone
-// @copyright   2015+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Darts_Data_Enhancer#readme
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Darts_Data_Enhancer#readme
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Darts Data Enhancer
+// @id              Darts_Data_Enhancer@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Enhances Darts Data
+// @author          jerone
+// @copyright       2015+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Darts_Data_Enhancer#readme
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Darts_Data_Enhancer#readme
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Darts_Data_Enhancer/Darts_Data_Enhancer.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     1.0.0
-// @grant       none
-// @run-at      document-end
-// @include     http://live.dartsdata.com/MatchesList.aspx
+// @version         1.0.0
+// @grant           none
+// @run-at          document-end
+// @include         http://live.dartsdata.com/MatchesList.aspx
 // ==/UserScript==
 
 var playersLeft = document.querySelectorAll("#ctl01 > table:nth-child(9) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2) > table > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(1) > div > table > tbody > tr > td:nth-child(2)");

--- a/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
+++ b/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
@@ -1,25 +1,25 @@
 // ==UserScript==
-// @name        GeenStijl & Powned & Dumpert Comment Enhancer
-// @namespace   https://github.com/jerone/UserScripts
-// @description Add features to enhance comments on GeenStijl & Powned & Dumpert & more.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/GeenStijl_Powned_Dumpert_Comment_Enhancer
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/GeenStijl_Powned_Dumpert_Comment_Enhancer
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            GeenStijl & Powned & Dumpert Comment Enhancer
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Add features to enhance comments on GeenStijl & Powned & Dumpert & more.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/GeenStijl_Powned_Dumpert_Comment_Enhancer
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/GeenStijl_Powned_Dumpert_Comment_Enhancer
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/GeenStijl_Powned_Dumpert_Comment_Enhancer/GeenStijl_Powned_Dumpert_Comment_Enhancer.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include     http*://*geenstijl.nl/mt/archieven/*
-// @include     http*://*geenstijl.tv/*
-// @include     http*://*powned.tv/nieuws/*
-// @include     http*://*dumpert.nl/mediabase/*
-// @include     http*://*daskapital.nl/*
-// @include     http*://*glamora.ma/*
-// @version     2.0
-// @grant       none
+// @include         http*://*geenstijl.nl/mt/archieven/*
+// @include         http*://*geenstijl.tv/*
+// @include         http*://*powned.tv/nieuws/*
+// @include         http*://*dumpert.nl/mediabase/*
+// @include         http*://*daskapital.nl/*
+// @include         http*://*glamora.ma/*
+// @version         2.0
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
+++ b/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
@@ -1,25 +1,25 @@
 // ==UserScript==
-// @name        GitHub Commit Compare
-// @namespace   https://github.com/jerone/UserScripts
-// @description Add controls to compare commits.
-// @author      jerone
-// @contributor darkred
-// @copyright   2017+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/GitHub_Commit_Compare
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/GitHub_Commit_Compare
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            GitHub Commit Compare
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Add controls to compare commits.
+// @author          jerone
+// @contributor     darkred
+// @copyright       2017+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/GitHub_Commit_Compare
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/GitHub_Commit_Compare
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/GitHub_Commit_Compare/GitHub_Commit_Compare.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @include     https://github.com/*/*/commits
-// @include     https://github.com/*/*/commits/*
-// @exclude     https://github.com/*/*.diff
-// @exclude     https://github.com/*/*.patch
-// @version     0.0.3
-// @grant       none
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @include         https://github.com/*/*/commits
+// @include         https://github.com/*/*/commits/*
+// @exclude         https://github.com/*/*.diff
+// @exclude         https://github.com/*/*.patch
+// @version         0.0.3
+// @grant           none
 // ==/UserScript==
 
 (function () {

--- a/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
+++ b/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
@@ -1,25 +1,26 @@
 // ==UserScript==
-// @id          Github_Comment_Enhancer@https://github.com/jerone/UserScripts
-// @name        Github Comment Enhancer
-// @namespace   https://github.com/jerone/UserScripts
-// @description Enhances Github comments
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Comment_Enhancer#readme
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Comment_Enhancer#readme
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Comment Enhancer
+// @id              Github_Comment_Enhancer@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Enhances Github comments
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Comment_Enhancer#readme
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Comment_Enhancer#readme
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Comment_Enhancer/Github_Comment_Enhancer.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     2.9.0
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @grant       none
-// @run-at      document-end
-// @include     https://github.com/*
-// @include     https://gist.github.com/*
+// @version         2.9.0
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @grant           none
+// @run-at          document-end
+// @include         https://github.com/*
+// @include         https://gist.github.com/*
 // ==/UserScript==
+
 /* global unsafeWindow */
 
 (function(unsafeWindow) {

--- a/Github_Commit_Diff/Github_Commit_Diff.user.js
+++ b/Github_Commit_Diff/Github_Commit_Diff.user.js
@@ -1,23 +1,23 @@
 // ==UserScript==
-// @name        Github Commit Diff
-// @namespace   https://github.com/jerone/UserScripts
-// @description Adds button to show diff (or patch) file for commit
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Commit_Diff
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Commit_Diff
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Commit_Diff/Github_Commit_Diff.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Commit_Diff/Github_Commit_Diff.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Commit Diff
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Adds button to show diff (or patch) file for commit
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Commit_Diff
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Commit_Diff
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Commit_Diff/Github_Commit_Diff.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Commit_Diff/Github_Commit_Diff.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @include     https://github.com/*
-// @exclude     https://github.com/*/*.diff
-// @exclude     https://github.com/*/*.patch
-// @version     1.6.7
-// @grant       none
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @include         https://github.com/*
+// @exclude         https://github.com/*/*.diff
+// @exclude         https://github.com/*/*.patch
+// @version         1.6.7
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
+++ b/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
@@ -1,21 +1,21 @@
 // ==UserScript==
-// @name        Github Commit Whitespace
-// @namespace   https://github.com/jerone/UserScripts
-// @description Adds button to hide whitespaces from commit
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Commit_Whitespace
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Commit_Whitespace
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Commit Whitespace
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Adds button to hide whitespaces from commit
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Commit_Whitespace
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Commit_Whitespace
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Commit_Whitespace/Github_Commit_Whitespace.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @include     https://github.com/*
-// @version     1.5.4
-// @grant       none
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @include         https://github.com/*
+// @version         1.5.4
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/Github_Gist_Share/157850.user.js
+++ b/Github_Gist_Share/157850.user.js
@@ -1,21 +1,21 @@
 // ==UserScript==
-// @name        Github Gist Share
-// @namespace   https://github.com/jerone/UserScripts/
-// @description Share your GitHub Gist to Twitter, Dabblet, Bl.ocks & as userscript.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Gist_Share
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Gist_Share
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Gist_Share/157850.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Gist_Share/157850.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Gist Share
+// @namespace       https://github.com/jerone/UserScripts/
+// @description     Share your GitHub Gist to Twitter, Dabblet, Bl.ocks & as userscript.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Gist_Share
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Gist_Share
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Gist_Share/157850.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Gist_Share/157850.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @include     *://gist.github.com/*
-// @version     5.1
-// @grant       none
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @include         *://gist.github.com/*
+// @version         5.1
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/Github_Image_Viewer/Github_Image_Viewer.user.js
+++ b/Github_Image_Viewer/Github_Image_Viewer.user.js
@@ -1,23 +1,23 @@
 // ==UserScript==
-// @id          Github_Image_Viewer@https://github.com/jerone/UserScripts
-// @name        Github Image Viewer
-// @namespace   https://github.com/jerone/UserScripts
-// @description Preview images from within the listing.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Image_Viewer
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Image_Viewer
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Image_Viewer/Github_Image_Viewer.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Image_Viewer/Github_Image_Viewer.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Image Viewer
+// @id              Github_Image_Viewer@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Preview images from within the listing.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Image_Viewer
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Image_Viewer
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Image_Viewer/Github_Image_Viewer.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Image_Viewer/Github_Image_Viewer.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     0.5.0
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @grant       none
-// @run-at      document-end
-// @include     https://github.com/*
+// @version         0.5.0
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @grant           none
+// @run-at          document-end
+// @include         https://github.com/*
 // ==/UserScript==
 
 (function() {

--- a/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
+++ b/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
@@ -1,27 +1,28 @@
 // ==UserScript==
-// @id          Github_JSON_Dependencies_Linker@https://github.com/jerone/UserScripts
-// @name        Github JSON Dependencies Linker
-// @namespace   https://github.com/jerone/UserScripts
-// @description Linkify all dependencies found in an JSON file.
-// @author      jerone
-// @copyright   2015+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_JSON_Dependencies_Linker
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_JSON_Dependencies_Linker
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github JSON Dependencies Linker
+// @id              Github_JSON_Dependencies_Linker@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Linkify all dependencies found in an JSON file.
+// @author          jerone
+// @copyright       2015+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_JSON_Dependencies_Linker
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_JSON_Dependencies_Linker
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_JSON_Dependencies_Linker/Github_JSON_Dependencies_Linker.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     0.3.2
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @grant       GM_xmlhttpRequest
-// @run-at      document-end
-// @include     https://github.com/*/package.json
-// @include     https://github.com/*/npm-shrinkwrap.json
-// @include     https://github.com/*/bower.json
-// @include     https://github.com/*/project.json
+// @version         0.3.2
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @grant           GM_xmlhttpRequest
+// @run-at          document-end
+// @include         https://github.com/*/package.json
+// @include         https://github.com/*/npm-shrinkwrap.json
+// @include         https://github.com/*/bower.json
+// @include         https://github.com/*/project.json
 // ==/UserScript==
+
 /* global GM_xmlhttpRequest */
 
 (function() {

--- a/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+++ b/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
@@ -1,24 +1,24 @@
 // ==UserScript==
-// @name        Github News Feed Filter
-// @namespace   https://github.com/jerone/UserScripts
-// @description Add filters for GitHub homepage news feed items
-// @author      jerone
-// @contributor darkred
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_News_Feed_Filter
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_News_Feed_Filter
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+// @name            Github News Feed Filter
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Add filters for GitHub homepage news feed items
+// @author          jerone
+// @contributor     darkred
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_News_Feed_Filter
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_News_Feed_Filter
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_News_Feed_Filter/Github_News_Feed_Filter.user.js
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @include     https://github.com/
-// @include     https://github.com/?*
-// @include     https://github.com/orgs/*/dashboard
-// @include     https://github.com/orgs/*/dashboard?*
-// @version     8.2.8
-// @grant       none
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @include         https://github.com/
+// @include         https://github.com/?*
+// @include         https://github.com/orgs/*/dashboard
+// @include         https://github.com/orgs/*/dashboard?*
+// @version         8.2.8
+// @grant           none
 // ==/UserScript==
 
 (function () {

--- a/Github_Pages_Linker/Github_Pages_Linker.user.js
+++ b/Github_Pages_Linker/Github_Pages_Linker.user.js
@@ -1,23 +1,23 @@
 // ==UserScript==
-// @id          Github_Pages_Linker@https://github.com/jerone/UserScripts
-// @name        Github Pages Linker
-// @namespace   https://github.com/jerone/UserScripts/
-// @description Add a link to Github Pages (gh-pages) when available.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Pages_Linker
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Pages_Linker
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Pages_Linker/Github_Pages_Linker.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Pages_Linker/Github_Pages_Linker.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Pages Linker
+// @id              Github_Pages_Linker@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts/
+// @description     Add a link to Github Pages (gh-pages) when available.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Pages_Linker
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Pages_Linker
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Pages_Linker/Github_Pages_Linker.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Pages_Linker/Github_Pages_Linker.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @version     1.2.5
-// @grant       none
-// @run-at      document-end
-// @include     https://github.com/*
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @version         1.2.5
+// @grant           none
+// @run-at          document-end
+// @include         https://github.com/*
 // ==/UserScript==
 
 (function () {

--- a/Github_Pull_Request_From/Github_Pull_Request_From.user.js
+++ b/Github_Pull_Request_From/Github_Pull_Request_From.user.js
@@ -1,23 +1,23 @@
 // ==UserScript==
-// @name        Github Pull Request From Link
-// @namespace   https://github.com/jerone/UserScripts/
-// @description Make pull request branches linkable
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Pull_Request_From
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Pull_Request_From
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Pull_Request_From/Github_Pull_Request_From.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Pull_Request_From/Github_Pull_Request_From.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Pull Request From Link
+// @namespace       https://github.com/jerone/UserScripts/
+// @description     Make pull request branches linkable
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Pull_Request_From
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Pull_Request_From
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Pull_Request_From/Github_Pull_Request_From.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Pull_Request_From/Github_Pull_Request_From.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @version     20.1
-// @grant       none
-// @include     https://github.com/*/pull/*
-// @exclude     https://github.com/*/*.diff
-// @exclude     https://github.com/*/*.patch
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @version         20.1
+// @grant           none
+// @include         https://github.com/*/pull/*
+// @exclude         https://github.com/*/*.diff
+// @exclude         https://github.com/*/*.patch
 // ==/UserScript==
 
 (function () {

--- a/Github_Reply_Comments/Github_Reply_Comments.user.js
+++ b/Github_Reply_Comments/Github_Reply_Comments.user.js
@@ -1,25 +1,25 @@
 // ==UserScript==
-// @name        Github Reply Comments
-// @namespace   https://github.com/jerone/UserScripts
-// @description Easy reply to Github comments
-// @author      jerone
-// @copyright   2016+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_Reply_Comments
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_Reply_Comments
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_Reply_Comments/Github_Reply_Comments.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_Reply_Comments/Github_Reply_Comments.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github Reply Comments
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Easy reply to Github comments
+// @author          jerone
+// @copyright       2016+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_Reply_Comments
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_Reply_Comments
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_Reply_Comments/Github_Reply_Comments.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_Reply_Comments/Github_Reply_Comments.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     1.0.5
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @grant       none
-// @include     https://github.com/*
-// @include     https://gist.github.com/*
-// @require     https://unpkg.com/turndown@5.0.3/dist/turndown.js
-// @require     https://unpkg.com/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js
-// @require     https://unpkg.com/turndown-plugin-github-code-snippet@1.0.2/turndown-plugin-github-code-snippet.js
+// @version         1.0.5
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @grant           none
+// @include         https://github.com/*
+// @include         https://gist.github.com/*
+// @require         https://unpkg.com/turndown@5.0.3/dist/turndown.js
+// @require         https://unpkg.com/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js
+// @require         https://unpkg.com/turndown-plugin-github-code-snippet@1.0.2/turndown-plugin-github-code-snippet.js
 // ==/UserScript==
 
 (function () {

--- a/Github_User_Info/Github_User_Info.user.js
+++ b/Github_User_Info/Github_User_Info.user.js
@@ -1,27 +1,27 @@
 // ==UserScript==
-// @id          Github_User_Info@https://github.com/jerone/UserScripts
-// @name        Github User Info
-// @namespace   https://github.com/jerone/UserScripts
-// @description Show inline user information on avatar hover.
-// @author      jerone
-// @copyright   2015+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Github_User_Info
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Github_User_Info
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Github_User_Info/Github_User_Info.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Github_User_Info/Github_User_Info.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Github User Info
+// @id              Github_User_Info@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Show inline user information on avatar hover.
+// @author          jerone
+// @copyright       2015+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Github_User_Info
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Github_User_Info
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Github_User_Info/Github_User_Info.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Github_User_Info/Github_User_Info.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://github.githubassets.com/pinned-octocat.svg
-// @version     0.4.1
-// @grant       GM_xmlhttpRequest
-// @grant       GM_setValue
-// @grant       GM_getValue
-// @grant       unsafeWindow
-// @run-at      document-end
-// @include     https://github.com/*
-// @include     https://gist.github.com/*
+// @icon            https://github.githubassets.com/pinned-octocat.svg
+// @version         0.4.1
+// @grant           GM_xmlhttpRequest
+// @grant           GM_setValue
+// @grant           GM_getValue
+// @grant           unsafeWindow
+// @run-at          document-end
+// @include         https://github.com/*
+// @include         https://gist.github.com/*
 // ==/UserScript==
 
 (function() {

--- a/Horizon_TV_Fixer/155147.user.js
+++ b/Horizon_TV_Fixer/155147.user.js
@@ -1,22 +1,22 @@
 // ==UserScript==
-// @name        Horizon TV Fixer
-// @namespace   https://github.com/jerone/UserScripts
-// @description Improves the Horizon / Ziggo TV Gids by extending the functionality and the layout of the site.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Horizon_TV_Fixer
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Horizon_TV_Fixer
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Horizon_TV_Fixer/155147.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Horizon_TV_Fixer/155147.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Horizon TV Fixer
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Improves the Horizon / Ziggo TV Gids by extending the functionality and the layout of the site.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Horizon_TV_Fixer
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Horizon_TV_Fixer
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Horizon_TV_Fixer/155147.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Horizon_TV_Fixer/155147.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @icon        https://www.ziggogo.tv/etc/designs/orion/theme/ziggo/favicon/favicon.ico
-// @version     31
-// @grant       none
-// @include     *horizon.tv*
-// @include     *ziggogo.tv*
+// @icon            https://www.ziggogo.tv/etc/designs/orion/theme/ziggo/favicon/favicon.ico
+// @version         31
+// @grant           none
+// @include         *horizon.tv*
+// @include         *ziggogo.tv*
 // ==/UserScript==
 
 (function HorizonTVFixer() {

--- a/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
+++ b/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
@@ -1,22 +1,22 @@
 // ==UserScript==
-// @id          Marktplaats_Exchanger@https://github.com/jerone/UserScripts
-// @name        Marktplaats Exchanger
-// @namespace   https://github.com/jerone/UserScripts
-// @description Exchange Marktplaats.nl
-// @author      jerone
-// @copyright   2015+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Marktplaats_Exchanger#readme
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Marktplaats_Exchanger#readme
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Marktplaats Exchanger
+// @id              Marktplaats_Exchanger@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Exchange Marktplaats.nl
+// @author          jerone
+// @copyright       2015+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Marktplaats_Exchanger#readme
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Marktplaats_Exchanger#readme
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Marktplaats_Exchanger/Marktplaats_Exchanger.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     1.0.1
-// @grant       none
-// @run-at      document-end
-// @include     https://www.marktplaats.*
+// @version         1.0.1
+// @grant           none
+// @run-at          document-end
+// @include         https://www.marktplaats.*
 // ==/UserScript==
 
 (function Marktplaats_Exchanger() {

--- a/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
+++ b/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
@@ -1,24 +1,25 @@
 // ==UserScript==
-// @id          Multiple_Windows_Live_IDs@https://github.com/jerone/UserScripts
-// @name        Multiple Windows Live IDs
-// @namespace   https://github.com/jerone/UserScripts
-// @description Easy login with multiple Microsoft accounts.
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Multiple Windows Live IDs
+// @id              Multiple_Windows_Live_IDs@https://github.com/jerone/UserScripts
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Easy login with multiple Microsoft accounts.
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Multiple_Windows_Live_IDs
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Multiple_Windows_Live_IDs/Multiple_Windows_Live_IDs.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @version     0.2.0
-// @grant       GM_getValue
-// @grant       GM_setValue
-// @run-at      document-end
-// @include     http*://login.live.com*
+// @version         0.2.0
+// @grant           GM_getValue
+// @grant           GM_setValue
+// @run-at          document-end
+// @include         http*://login.live.com*
 // ==/UserScript==
+
 /* global GM_getValue,GM_setValue */
 
 (function() {

--- a/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
+++ b/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
@@ -1,20 +1,20 @@
 // ==UserScript==
-// @name        Outlook Sign Out To Login
-// @namespace   https://github.com/jerone/UserScripts
-// @description Redirect back to login page when signing out from Outlook
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Outlook_Sign_Out_To_Login
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Outlook_Sign_Out_To_Login
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Outlook Sign Out To Login
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Redirect back to login page when signing out from Outlook
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Outlook_Sign_Out_To_Login
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Outlook_Sign_Out_To_Login
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Outlook_Sign_Out_To_Login/Outlook_Sign_Out_To_Login.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include     *://*.mail.live.com/*
-// @version     1
-// @grant       none
+// @include         *://*.mail.live.com/*
+// @version         1
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/PDF_Tools/PDF_Tools.user.js
+++ b/PDF_Tools/PDF_Tools.user.js
@@ -1,18 +1,18 @@
 // ==UserScript==
-// @id             PDF_Tools@https://github.com/jerone/UserScripts
-// @name           PDF Tools
-// @description    An userscript that enhances the pdf.js window in Firefox.
-// @version        1.0
-// @namespace      https://github.com/jerone/UserScripts
-// @author         jerone
-// @license        CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license        GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @supportURL     https://github.com/jerone/UserScripts/issues
+// @name            PDF Tools
+// @id              PDF_Tools@https://github.com/jerone/UserScripts
+// @description     An userscript that enhances the pdf.js window in Firefox.
+// @version         1.0
+// @namespace       https://github.com/jerone/UserScripts
+// @author          jerone
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include        *.pdf
-// @include        *.pdf?*
-// @include        *.pdf#*
-// @run-at         document-end
+// @include         *.pdf
+// @include         *.pdf?*
+// @include         *.pdf#*
+// @run-at          document-end
 // ==/UserScript==
 
 (function() {

--- a/Twitter_profile_replies_hider/Twitter_profile_replies_hider.user.js
+++ b/Twitter_profile_replies_hider/Twitter_profile_replies_hider.user.js
@@ -1,22 +1,22 @@
 // ==UserScript==
-// @name        Twitter profile replies hider
-// @namespace   https://github.com/jerone/UserScripts
-// @description Hide replies on Twitter profiles
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Hide_replies_on_Twitter_user_account
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Hide_replies_on_Twitter_user_account
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Hide_replies_on_Twitter_user_account/163703.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Hide_replies_on_Twitter_user_account/163703.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Twitter profile replies hider
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Hide replies on Twitter profiles
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Hide_replies_on_Twitter_user_account
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Hide_replies_on_Twitter_user_account
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Hide_replies_on_Twitter_user_account/163703.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Hide_replies_on_Twitter_user_account/163703.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include     *://twitter.com/*
-// @exclude     *://twitter.com/
-// @exclude     *://twitter.com
-// @version     5
-// @grant       none
+// @include         *://twitter.com/*
+// @exclude         *://twitter.com/
+// @exclude         *://twitter.com
+// @version         5
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/Twitter_profile_retweets_hider/Twitter_profile_retweets_hider.user.js
+++ b/Twitter_profile_retweets_hider/Twitter_profile_retweets_hider.user.js
@@ -1,22 +1,22 @@
 // ==UserScript==
-// @name        Twitter profile retweets hider
-// @namespace   https://github.com/jerone/UserScripts
-// @description Hide retweets on Twitter profiles
-// @author      jerone
-// @copyright   2014+, jerone (https://github.com/jerone)
-// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @homepage    https://github.com/jerone/UserScripts/tree/master/Hide_retweets_on_Twitter_user_account
-// @homepageURL https://github.com/jerone/UserScripts/tree/master/Hide_retweets_on_Twitter_user_account
-// @downloadURL https://github.com/jerone/UserScripts/raw/master/Hide_retweets_on_Twitter_user_account/173703.user.js
-// @updateURL   https://github.com/jerone/UserScripts/raw/master/Hide_retweets_on_Twitter_user_account/173703.user.js
-// @supportURL  https://github.com/jerone/UserScripts/issues
+// @name            Twitter profile retweets hider
+// @namespace       https://github.com/jerone/UserScripts
+// @description     Hide retweets on Twitter profiles
+// @author          jerone
+// @copyright       2014+, jerone (https://github.com/jerone)
+// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @homepage        https://github.com/jerone/UserScripts/tree/master/Hide_retweets_on_Twitter_user_account
+// @homepageURL     https://github.com/jerone/UserScripts/tree/master/Hide_retweets_on_Twitter_user_account
+// @downloadURL     https://github.com/jerone/UserScripts/raw/master/Hide_retweets_on_Twitter_user_account/173703.user.js
+// @updateURL       https://github.com/jerone/UserScripts/raw/master/Hide_retweets_on_Twitter_user_account/173703.user.js
+// @supportURL      https://github.com/jerone/UserScripts/issues
 // @contributionURL https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VCYMHWQ7ZMBKW
-// @include     *://twitter.com/*
-// @exclude     *://twitter.com/
-// @exclude     *://twitter.com
-// @version     2
-// @grant       none
+// @include         *://twitter.com/*
+// @exclude         *://twitter.com/
+// @exclude         *://twitter.com
+// @version         2
+// @grant           none
 // ==/UserScript==
 
 (function() {

--- a/Userscripts.org_Diff_Extender/38909.user.js
+++ b/Userscripts.org_Diff_Extender/38909.user.js
@@ -1,19 +1,19 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Diff Extender
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/38909
-// @description     Add some handy features to the diff.
-// @description     Userscripts.org Diff Extender v2.2.1 Alpha
-// @copyright       2008 - 2012 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         v2.2.1 Alpha
-// @browser         FF17
-// @include         *userscripts.org/scripts/diff/*
-// @grant           none
+// ==UserScript==
+// @name        Userscripts.org Diff Extender
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/38909
+// @homepageURL http://userscripts.org/scripts/show/38909
+// @description Add some handy features to the diff. -- Userscripts.org Diff Extender v2.2.1 Alpha
+// @copyright   2008 - 2012 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     v2.2.1-alpha
+// @browser     FF17
+// @include     *userscripts.org/scripts/diff/*
+// @grant       none
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 // ToC:
 // - Copyrights

--- a/Userscripts.org_Extended_Style/37212.user.js
+++ b/Userscripts.org_Extended_Style/37212.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
-// @name           Userscripts.org Extended Style
-// @namespace      http://userscripts.org/scripts/show/37212
-// @description    Userscripts.org Extended Style
-// @copyright      jerone & Jesse A.
-// @license        CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license        GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @include        *userscripts.org*
-// @grant          GM_addStyle
+// @name        Userscripts.org Extended Style
+// @namespace   http://userscripts.org/scripts/show/37212
+// @version     0.0.1
+// @description Userscripts.org Extended Style
+// @copyright   jerone & Jesse A.
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @include     *userscripts.org*
+// @grant       GM_addStyle
 // ==/UserScript==
 
 GM_addStyle("												\

--- a/Userscripts.org_Scripts_Source_Counter/37611.user.js
+++ b/Userscripts.org_Scripts_Source_Counter/37611.user.js
@@ -1,21 +1,21 @@
-/*//////////////////////////////////////////////////////////////////////////
 // ==UserScript==
-// @name            Userscripts.org Scripts Source Counter
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/37611
-// @description     Count all characters, words and lines for scriptwriters.
-// @description     Userscripts.org Scripts Source Counter v3
-// @copyright       2008 - 2013 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         3
-// @browser         FF19
-// @grant           none
-// @include         *userscripts.org/scripts/new?form=true
-// @include         *userscripts.org/scripts/edit_src/*
+// @name        Userscripts.org Scripts Source Counter
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/37611
+// @homepageURL http://userscripts.org/scripts/show/37611
+// @description Count all characters, words and lines for scriptwriters. -- Userscripts.org Scripts Source Counter v3
+// @copyright   2008 - 2013 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     3
+// @browser     FF19
+// @grant       none
+// @include     *userscripts.org/scripts/new?form=true
+// @include     *userscripts.org/scripts/edit_src/*
 // ==/UserScript==
-////////////////////////////////////////////////////////////////////////////
+
+/*//////////////////////////////////////////////////////////////////////////
 THIS  SCRIPT  IS  PROVIDED BY THE AUTHOR `AS IS' AND ANY EXPRESS OR IMPLIED
 WARRANTIES,  INCLUDING, BUT  NOT  LIMITED  TO, THE  IMPLIED  WARRANTIES  OF
 MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO

--- a/Userscripts.org_Source_Numbering/38912.user.js
+++ b/Userscripts.org_Source_Numbering/38912.user.js
@@ -1,17 +1,17 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Source Numbering
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/38912
-// @description     Add line numbering to source code.
-// @description     Userscripts.org Source Numbering v3
-// @copyright       2008 - 2013 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         v3
-// @include         *userscripts.org/scripts/review/*
+// ==UserScript==
+// @name        Userscripts.org Source Numbering
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/38912
+// @homepageURL http://userscripts.org/scripts/show/38912
+// @description Add line numbering to source code. -- Userscripts.org Source Numbering v3
+// @copyright   2008 - 2013 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     v3
+// @include     *userscripts.org/scripts/review/*
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 THIS  SCRIPT  IS  PROVIDED BY THE AUTHOR `AS IS' AND ANY EXPRESS OR IMPLIED
 WARRANTIES,  INCLUDING, BUT  NOT  LIMITED  TO, THE  IMPLIED  WARRANTIES  OF

--- a/Userscripts.org_Timed_Updater/37853.user.js
+++ b/Userscripts.org_Timed_Updater/37853.user.js
@@ -1,19 +1,19 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Timed Updater
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/37853
-// @description     Update or create script at specific time.
-// @description     Userscripts.org Timed Updater v2.0.1 Alpha
-// @copyright       2008 - 2012 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         v2.0.1 Alpha
-// @browser         FF17
-// @include         *userscripts.org/scripts/new?form=true
-// @include         *userscripts.org/scripts/edit_src/*
+// ==UserScript==
+// @name        Userscripts.org Timed Updater
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/37853
+// @homepageURL http://userscripts.org/scripts/show/37853
+// @description Update or create script at specific time. -- Userscripts.org Timed Updater v2.0.1 Alpha
+// @copyright   2008 - 2012 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     v2.0.1-alpha
+// @browser     FF17
+// @include     *userscripts.org/scripts/new?form=true
+// @include     *userscripts.org/scripts/edit_src/*
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 // ToC:
 // - Copyrights

--- a/Userscripts.org_Topics_Column/38597.user.js
+++ b/Userscripts.org_Topics_Column/38597.user.js
@@ -1,19 +1,19 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Topics Column
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/38597
-// @description     Add extra column with scripts topics in script management.
-// @description     Userscripts.org Topics Column v2.1.1 Alpha
-// @copyright       2008 - 2012 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         v2.1.1 Alpha
-// @browser         FF17
-// @include         *userscripts.org/home/scripts
-// @include         *userscripts.org/home/scripts*
+// ==UserScript==
+// @name        Userscripts.org Topics Column
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/38597
+// @homepageURL http://userscripts.org/scripts/show/38597
+// @description Add extra column with scripts topics in script management. -- Userscripts.org Topics Column v2.1.1 Alpha
+// @copyright   2008 - 2012 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     v2.1.1-alpha
+// @browser     FF17
+// @include     *userscripts.org/home/scripts
+// @include     *userscripts.org/home/scripts*
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 // ToC:
 // - Copyrights

--- a/Userscripts.org_Versions_Column/38595.user.js
+++ b/Userscripts.org_Versions_Column/38595.user.js
@@ -1,19 +1,19 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Versions Column
-// @author          Jerone UserScript Productions
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/38595
-// @description     Add extra column with scripts versions in script management.
-// @description     Userscripts.org Versions Column v1.3.1 Alpha
-// @copyright       2008 - 2012 Jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         v1.3.1 Alpha
-// @browser         FF17
-// @include         *userscripts.org/home/scripts
-// @include         *userscripts.org/home/scripts*
+// ==UserScript==
+// @name        Userscripts.org Versions Column
+// @author      Jerone UserScript Productions
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/38595
+// @homepageURL http://userscripts.org/scripts/show/38595
+// @description Add extra column with scripts versions in script management. -- Userscripts.org Versions Column v1.3.1 Alpha
+// @copyright   2008 - 2012 Jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     v1.3.1-alpha
+// @browser     FF17
+// @include     *userscripts.org/home/scripts
+// @include     *userscripts.org/home/scripts*
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 // ToC:
 // - Copyrights

--- a/Userscripts.org_Versions_Tab/38594.user.js
+++ b/Userscripts.org_Versions_Tab/38594.user.js
@@ -1,22 +1,22 @@
-////////////////////////////////////////////////////////////////////////////
-// ==UserScript===
-// @name            Userscripts.org Versions Tab
-// @author          jerone
-// @namespace       http://userscripts.org/users/31497
-// @homepage        http://userscripts.org/scripts/show/38594
-// @description     Add versions tab to scripts menu.
-// @description     Userscripts.org Versions Tab 3.4
-// @copyright       2008 - 2013 jerone
-// @license         CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-// @license         GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
-// @version         3.4
-// @include         *userscripts.org/scripts/*
-// @include         *userscripts.org/topics/*
-// @include         *userscripts.org/reviews/*
-// @grant           GM_getValue
-// @grant           GM_setValue
-// @grant           GM_xmlhttpRequest
+// ==UserScript==
+// @name        Userscripts.org Versions Tab
+// @author      jerone
+// @namespace   http://userscripts.org/users/31497
+// @homepage    http://userscripts.org/scripts/show/38594
+// @homepageURL http://userscripts.org/scripts/show/38594
+// @description Add versions tab to scripts menu. -- Userscripts.org Versions Tab 3.4
+// @copyright   2008 - 2013 jerone
+// @license     CC-BY-NC-SA-4.0; https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+// @license     GPL-3.0-or-later; http://www.gnu.org/licenses/gpl-3.0.txt
+// @version     3.4
+// @include     *userscripts.org/scripts/*
+// @include     *userscripts.org/topics/*
+// @include     *userscripts.org/reviews/*
+// @grant       GM_getValue
+// @grant       GM_setValue
+// @grant       GM_xmlhttpRequest
 // ==/UserScript==
+
 /*//////////////////////////////////////////////////////////////////////////
 THIS  SCRIPT  IS  PROVIDED BY THE AUTHOR `AS IS' AND ANY EXPRESS OR IMPLIED
 WARRANTIES,  INCLUDING, BUT  NOT  LIMITED  TO, THE  IMPLIED  WARRANTIES  OF

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "userscripts",
+  "version": "0.0.0",
+  "scripts": {
+    "lint": "eslint **/*.js"
+  },
+  "devDependencies": {
+    "eslint": "^8.55.0",
+    "eslint-plugin-userscripts": "^0.5.1"
+  }
+}


### PR DESCRIPTION
Adds the `eslint-plugin-userscripts` plugin to validate userscript metadata.

Here are the changes that could result in functionality differences summarized:

- I found some of the versions used the following format: `vx.x.x Alpha`, and changed them to `vx.x.x-alpha`. I am not sure if Tampermonkey supports this format, but there isn't any examples with such a format in their documentation: https://www.tampermonkey.net/documentation.php#meta:version . Also, ViolentMonkey doesn't support this version in their version comparison:
https://github.com/violentmonkey/violentmonkey/blob/8627b2a3896a00a31e383c4ebf3eb21a25e757f2/src/common/util.js#L135
- I modified [`Userscripts.org_Extended_Style/37212.user.js`](https://github.com/jerone/UserScripts/compare/master...Yash-Singh1:jerone-UserScripts:master#diff-c663b3158a42ccdcdff060dd6ee4e79938849a5a56226557a5c235a416941d6e) to include `0.0.1` as the `@version`

The rest were autofixes for code style (e.g. spacing between metadata and code, attribute spacing, name at top, etc).